### PR TITLE
Allow <script>-Tags

### DIFF
--- a/src/main/java/net/vaemendis/hccd/CardGenerator.java
+++ b/src/main/java/net/vaemendis/hccd/CardGenerator.java
@@ -87,6 +87,9 @@ public class CardGenerator {
                 "<html>" +
                 "<head>" +
                 "<meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\"></meta>" +
+				"<meta http-equiv=\"Content-Security-Policy\" content=\"script-src 'unsafe-inline';\">" +
+				"<meta http-equiv=\"X-Content-Security-Policy\" content=\"script-src 'unsafe-inline';\">" + 
+				"<meta http-equiv=\"X-WebKit-CSP\" content=\"script-src 'unsafe-inline';\">" +
                 "<link rel=\"stylesheet\" type=\"text/css\" href=\"");
         sb.append(cssFilePath);
         sb.append("\"><style>" +


### PR DESCRIPTION
HCCD now writes Meta-Tags allowing for the use of <script>-tags inside the card's HTML, which is VERY useful when dealing with more complex cases for your card games.

Oh and...   happy new year by the same you are probably seeing this :wink: 